### PR TITLE
Remove React 15.2.x warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-search-input",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "description": "Simple react.js component for a search input, providing a filter function.",
   "main": "lib/index.js",
   "jsnext:main": "src/index.js",

--- a/src/index.js
+++ b/src/index.js
@@ -43,7 +43,7 @@ const Search = React.createClass({
   },
 
   render () {
-    const {className, onChange, caseSensitive, throttle, filterKeys, value, ...inputProps} = this.props
+    const {className, onChange, caseSensitive, throttle, filterKeys, value, fuzzy, ...inputProps} = this.props
     inputProps.type = inputProps.type || 'search'
     inputProps.value = this.state.searchTerm
     inputProps.onChange = this.updateSearch


### PR DESCRIPTION
Per https://github.com/enkidevs/react-search-input/issues/61

React throws warning/error that prop is being pushed from parent to child.  This fix just prevents fuzzy from being passed farther down.

https://gist.github.com/jimfb/d99e0678e9da715ccf6454961ef04d1b
