### PR TITLE
Refactor from React.PropTypes to prop-types

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
   },
   "homepage": "https://github.com/enkidevs/react-search-input",
   "dependencies": {
-    "fuse.js": "^2.2.0"
+    "fuse.js": "^2.2.0",
+    "prop-types": "^15.5.8"
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,19 +1,20 @@
 import React from 'react'
+import PropTypes from 'prop-types'
 import { createFilter } from './util'
 
 const Search = React.createClass({
   propTypes: {
-    className: React.PropTypes.string,
-    inputClassName: React.PropTypes.string,
-    onChange: React.PropTypes.func,
-    caseSensitive: React.PropTypes.bool,
-    fuzzy: React.PropTypes.bool,
-    throttle: React.PropTypes.number,
-    filterKeys: React.PropTypes.oneOf([
-      React.PropTypes.string,
-      React.PropTypes.arrayOf(React.PropTypes.string)
+    className: PropTypes.string,
+    inputClassName: PropTypes.string,
+    onChange: PropTypes.func,
+    caseSensitive: PropTypes.bool,
+    fuzzy: PropTypes.bool,
+    throttle: PropTypes.number,
+    filterKeys: PropTypes.oneOf([
+      PropTypes.string,
+      PropTypes.arrayOf(PropTypes.string)
     ]),
-    value: React.PropTypes.string
+    value: PropTypes.string
   },
 
   getDefaultProps () {


### PR DESCRIPTION
The direct access of `React.PropTypes` is deprecated.
This PR add the `prop-types` dependency and changes PropType definitions to make use of it.